### PR TITLE
Do not use trailing slash and script end tag

### DIFF
--- a/library/template/filter/script.php
+++ b/library/template/filter/script.php
@@ -109,10 +109,10 @@ class TemplateFilterScript extends TemplateFilterTag
             if($condition)
             {
                 $html  = '<!--[if '.$condition.']>';
-                $html .= '<script src="'.$link.'" '.$attribs.' /></script>'."\n";
+                $html .= '<script src="'.$link.'" '.$attribs.'></script>'."\n";
                 $html .= '<![endif]-->';
             }
-            else $html  = '<script src="'.$link.'" '.$attribs.' /></script>'."\n";
+            else $html  = '<script src="'.$link.'" '.$attribs.'></script>'."\n";
         }
 
 		return $html;


### PR DESCRIPTION
When the script tags for the template are processed, the resulting markup is rendered with a trailing slash (as used in self-closing tags) as well as an ending </script> tag:

```
<script {…} /></script>
```
