### PR TITLE
Filter html

### DIFF
--- a/library/filter/html.php
+++ b/library/filter/html.php
@@ -461,7 +461,10 @@ class FilterHtml extends FilterTidy
             }, $string);
 
         // Convert hex
-        $string = preg_replace('/&#x([a-f0-9]+);/mei', "utf8_encode(chr(0x\\1))", $string);
+        $string = preg_replace_callback('/&#x([a-f0-9]+);/mi',
+            function($matches){
+                return utf8_encode(chr('0x'.$matches[1]));
+            }, $string);
 
         return $string;
     }


### PR DESCRIPTION
Updated filter html to use preg_replace_callback as preg_replace with /e modifier is depricated in php 5.5
