### PR TITLE
TemplateHelperSelect calling undefined translate() method

### DIFF
--- a/library/template/helper/select.php
+++ b/library/template/helper/select.php
@@ -131,7 +131,7 @@ class TemplateHelperSelect extends TemplateHelperAbstract implements TemplateHel
             foreach ($options as $option)
             {
                 $value = $option->value;
-                $label = $config->translate ? $this->translate( $option->label ) : $option->label;
+                $label = $config->translate ? $translator( $option->label ) : $option->label;
 
                 $extra = '';
                 if(isset($option->disable) && $option->disable) {


### PR DESCRIPTION
Fixed TemplateHelperSelect translate call to $translator instead of $this->translate which is undefined
