### PR TITLE
Added missing koowa.js to ckeditor template

### DIFF
--- a/component/ckeditor/view/editor/templates/default.html.php
+++ b/component/ckeditor/view/editor/templates/default.html.php
@@ -8,6 +8,7 @@
  */
 ?>
 
+<ktml:script src="assets://js/koowa.js" />
 <ktml:script src="assets://ckeditor/ckeditor/ckeditor.js" />
 <ktml:script src="assets://ckeditor/js/ckeditor.koowa.js" />
 


### PR DESCRIPTION
If koowa.js isn't already loaded, ckeditor's js errors due to missing Koowa.Controller
