### PR TITLE
Updated error_reporting to use & instead of |

### DIFF
--- a/application/admin/public/bootstrap.php
+++ b/application/admin/public/bootstrap.php
@@ -16,7 +16,7 @@
 use Nooku\Library;
 
 //Don't run in STRICT mode (Joomla is not E_STRICT compat)
-error_reporting(error_reporting() | ~ E_STRICT);
+error_reporting(error_reporting() & ~ E_STRICT);
 
 define( 'DS', DIRECTORY_SEPARATOR );
 

--- a/application/site/public/bootstrap.php
+++ b/application/site/public/bootstrap.php
@@ -16,7 +16,7 @@
 use Nooku\Library;
 
 //Don't run in STRICT mode (Joomla is not E_STRICT compat)
-error_reporting(error_reporting() | ~ E_STRICT);
+error_reporting(error_reporting() & ~ E_STRICT);
 
 define( 'DS', DIRECTORY_SEPARATOR );
 


### PR DESCRIPTION
Error reporting set in bootstrapper.php was using | to remove strict errors, should be &
