### PR TITLE
Fixed FilterHtml inline with php 5.5 depricated methods

### DIFF
--- a/library/filter/html.php
+++ b/library/filter/html.php
@@ -455,10 +455,14 @@ class FilterHtml extends FilterTidy
         $string = html_entity_decode($string, ENT_COMPAT, "UTF-8");
 
         // Convert decimal
-        $string = preg_replace('/&#(\d+);/me', "utf8_encode(chr(\\1))", $string);
+        $string = preg_replace_callback('/&#(\d+);/m', function($matches){
+            return utf8_encode(chr($matches[1]));
+        }, $string);
 
         // Convert hex
-        $string = preg_replace('/&#x([a-f0-9]+);/mei', "utf8_encode(chr(0x\\1))", $string);
+        $string = preg_replace_callback('/&#x([a-f0-9]+);/mi', function($matches){
+            return utf8_encode(chr('0x'.$matches[1]));
+        }, $string);
 
         return $string;
     }


### PR DESCRIPTION
/e regex modifier is depricated in PHP 5.5, removed and replaced with closure
