### PR TITLE
Removed final from decorator __set

### DIFF
--- a/library/object/decorator/abstract.php
+++ b/library/object/decorator/abstract.php
@@ -165,7 +165,7 @@ abstract class ObjectDecoratorAbstract implements ObjectDecoratorInterface
      * @param  mixed  $value The variable value.
      * @return mixed
      */
-    final public function __set($key, $value)
+    public function __set($key, $value)
     {
         $this->getDelegate()->$key = $value;
     }


### PR DESCRIPTION
Decorator has an unnecessary final on it's __set method meaning subclasses can't override. 
