### PR TITLE
Removed abstract declaration from AttachmentsControllerAttachment

### DIFF
--- a/application/site/component/attachments/controller/attachment.php
+++ b/application/site/component/attachments/controller/attachment.php
@@ -16,7 +16,7 @@ use Nooku\Component\Attachments;
  * @author  Johan Janssens <http://github.com/johanjanssens>
  * @package Component\Attachments
  */
-abstract class AttachmentsControllerAttachment extends Attachments\ControllerAttachment
+class AttachmentsControllerAttachment extends Attachments\ControllerAttachment
 {
 
 }


### PR DESCRIPTION
Whilst attempting to get file uploading working in the frontend and submitting this PR (https://github.com/nooku/nooku-platform/pull/13)

I found that AttachmentsControllerAttachment is declared abstract, yet ControllerBehaviorAttachable::118 attempts to create an instance of it.

Is this intentional or a bug?
