### PR TITLE
Module blocks invalidate markup

### DIFF
--- a/component/pages/template/filter/module.php
+++ b/component/pages/template/filter/module.php
@@ -149,7 +149,7 @@ class TemplateFilterModule extends Library\TemplateFilterAbstract
         $replace = array();
         $matches = array();
         // <ktml:modules position="[position]"></khtml:modules>
-        if(preg_match_all('#<ktml:modules\s+position="([^"]+)"(.*)>(.*)</ktml:modules>#siU', $text, $matches))
+        if(preg_match_all('#<ktml:modules\s+position="([^"]+)"(.*)>(.*)(</ktml:modules>)#siU', $text, $matches))
         {
             $count = count($matches[1]);
 
@@ -166,6 +166,9 @@ class TemplateFilterModule extends Library\TemplateFilterAbstract
                 }
             }
 
+            // Catch the closing tag and remove it
+            $text = str_replace($matches[3],'', $text);
+            
             $text = str_replace($matches[0], $replace, $text);
         }
 


### PR DESCRIPTION
The closing tags /ktml:modules are not being removed from the rendered content. This is causing layouts to break and markup validation will fail as well.
This patch solves it by catching the closing tag and removing it.
