### PR TITLE
Admin error pages, scrollable & selectable

### DIFF
--- a/application/admin/component/application/view/page/templates/error.html.php
+++ b/application/admin/component/application/view/page/templates/error.html.php
@@ -11,6 +11,7 @@
 <!DOCTYPE HTML>
 <html lang="<?= $language; ?>">
 <?= import('page_head.html') ?>
+<ktml:style src="assets://application/stylesheets/error.css" />
 
 <body>
 <ktml:content>

--- a/application/admin/public/theme/default/stylesheets/error.css
+++ b/application/admin/public/theme/default/stylesheets/error.css
@@ -1,0 +1,11 @@
+@charset "UTF-8";
+
+html, body{
+    overflow: auto;
+    display: block;
+    height: auto;
+    -moz-user-select: -moz-inherit;
+    -ms-user-select: inherit;
+    -webkit-user-select: inherit;
+    user-select: inherit;
+}


### PR DESCRIPTION
Forced error pages to override admin CSS so that they're scrollable and text is selectable