### PR TITLE
Updated template to filter all rendered strings

### DIFF
--- a/library/template/template.php
+++ b/library/template/template.php
@@ -191,8 +191,9 @@ class Template extends TemplateAbstract implements TemplateFilterable, TemplateH
         if($this->_source instanceof TemplateEngineInterface)
         {
             $this->_source = $this->_source->render($data);
-            $this->_source = $this->filter();
         }
+        
+        $this->_source = $this->filter();
 
         return $this->_source;
     }


### PR DESCRIPTION
Currently filtering is only performed when loading a template engine as the source. If loading a string, template filtering doesn't happen, even though filtering is always performed on a string