### PR TITLE
Updated TemplateLocatorComponent to use first template found

### DIFF
--- a/library/template/locator/component.php
+++ b/library/template/locator/component.php
@@ -67,7 +67,7 @@ class TemplateLocatorComponent extends TemplateLocatorIdentifier
                 foreach($results as $file)
                 {
                     if($result = $this->realPath($file)) {
-                        break;
+                        break(2);
                     }
                 }
             }


### PR DESCRIPTION
Given the order is /application/XX then /component/XX if a file is found in the application version of the component, that should be used and the loop broken, else the parent for loop will continue onto the next location and that will take precedence.