### PR TITLE
Patched ObjectConfig::append() to handle merging an index array into a non-indexed

### DIFF
--- a/library/object/config/config.php
+++ b/library/object/config/config.php
@@ -168,10 +168,11 @@ class ObjectConfig implements ObjectConfigInterface
 
             if(is_array($options) || $options instanceof \Traversable)
             {
-                if(!is_numeric(key($options)))
+                foreach($options as $key => $value)
                 {
-                    foreach($options as $key => $value)
-                    {
+                    if(is_numeric($key)){
+                        $this->__options[] = $value;
+                    }else{
                         if(array_key_exists($key, $this->__options))
                         {
                             if(!empty($value) && ($this->__options[$key] instanceof ObjectConfig)) {
@@ -179,15 +180,6 @@ class ObjectConfig implements ObjectConfigInterface
                             }
                         }
                         else $this->set($key, $value);
-                    }
-                }
-                else
-                {
-                    foreach($options as $value)
-                    {
-                        if (!in_array($value, $this->__options, true)) {
-                            $this->__options[] = $value;
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Currently:

```php
$config = new Nooku\Library\ObjectConfig([
    'authenticators' => ['three']
]);

$config->append([
    'authenticators' => ['one', 'two' => array(2 => 2)]
]);
```

Produces:
```
[
'one',
'three',
[2 => 2]
]
```

This patch fixes this and produces the correct result:
```
[
'one',
'three',
'two' => [2 => 2]
]
```