### PR TITLE
Made ClassLocatorComposer throw exception if vendor_path is not supplied

### DIFF
--- a/library/class/locator/composer.php
+++ b/library/class/locator/composer.php
@@ -46,7 +46,7 @@ class ClassLocatorComposer extends ClassLocatorAbstract
         }
 
         //Let Nooku proxy class loading
-        $this->_loader = require $config['vendor_path'].'/autoload.php';
+        $this->_loader = require_once $config['vendor_path'].'/autoload.php';
     }
 
     /**

--- a/library/class/locator/composer.php
+++ b/library/class/locator/composer.php
@@ -40,14 +40,13 @@ class ClassLocatorComposer extends ClassLocatorAbstract
      */
     public function __construct($config = array())
     {
-        if(isset($config['vendor_path']))
+        if(!isset($config['vendor_path']) || !file_exists($config['vendor_path'].'/autoload.php'))
         {
-            if(file_exists($config['vendor_path'].'/autoload.php'))
-            {
-                //Let Nooku proxy class loading
-                $this->_loader = require $config['vendor_path'].'/autoload.php';
-            }
+            throw new \InvalidArgumentException('ClassLocatorComposer requires "vendor_path" config parameter');
         }
+
+        //Let Nooku proxy class loading
+        $this->_loader = require $config['vendor_path'].'/autoload.php';
     }
 
     /**


### PR DESCRIPTION
Call can be instantiated and loaded without supplying a vendor_path which causes an exception when `$this->_loader->findFile($class);` is called