### PR TITLE
Refactored ObjectManager::getIdentifier() for efficiency

### DIFF
--- a/library/object/manager/manager.php
+++ b/library/object/manager/manager.php
@@ -233,17 +233,17 @@ class ObjectManager implements ObjectInterface, ObjectManagerInterface, ObjectSi
         //Get the identifier
         if(isset($identifier))
         {
-            if(!$identifier instanceof ObjectIdentifierInterface)
-            {
-                if ($identifier instanceof ObjectInterface) {
-                    $identifier = $identifier->getIdentifier();
-                } else {
-                    $identifier = new ObjectIdentifier($identifier);
-                }
+            if ($identifier instanceof ObjectInterface) {
+                $identifier = $identifier->getIdentifier();
             }
 
             //Get the identifier object
             if (!$result = $this->__registry->find($identifier)) {
+
+                if(!$identifier instanceof ObjectIdentifierInterface) {
+                    $identifier = new ObjectIdentifier($identifier);
+                }
+
                 $result = $this->__registry->set($identifier);
             }
         }


### PR DESCRIPTION
Currently, calling getIdentifier() with a string, converts this into an identifier object, then checks the registry by converting it into a string and checking if the index exists in the `find()` method of the registry.

This patch flips the logic to convert an identifier into a string if it's not a string, since the registry check converts it into a string anyway.

I found this achieves a 5x speed improvement in speed.