### PR TITLE
Implemented namespace/classname => locator map

### DIFF
--- a/library/class/loader.php
+++ b/library/class/loader.php
@@ -85,7 +85,7 @@ class ClassLoader implements ClassLoaderInterface
         $this->registerLocator(new ClassLocatorLibrary($config));
 
         //Register the Nooku\Library namesoace
-        $this->registerLocatorNamespaces( 'library', [__NAMESPACE__ => dirname(dirname(__FILE__))]);
+        $this->registerLocatorNamespaces( 'library', array(__NAMESPACE__ => dirname(dirname(__FILE__))));
 
         //Register the loader with the PHP autoloader
         $this->register();

--- a/library/class/loader.php
+++ b/library/class/loader.php
@@ -199,7 +199,7 @@ class ClassLoader implements ClassLoaderInterface
 
             foreach($locators as $name => $path)
             {
-                $locator = $this->_locators[$name];
+                $locator = $this->getLocator($name);
 
                 if(false !== $result = $locator->locate($class, $path ?: $base)) {
                     break;
@@ -312,7 +312,7 @@ class ClassLoader implements ClassLoaderInterface
         $name = $locator->getName();
 
         //Ensure locator is register already
-        if (!isset($this->_locators[$name])) {
+        if (!$this->getLocator($name)) {
             throw new \InvalidArgumentException('The locator '.$name.' passed to '.__CLASS__.'::'.__FUNCTION__.' is not registered. Please call registerLocator() instead');
         }
 

--- a/library/class/loader.php
+++ b/library/class/loader.php
@@ -9,13 +9,13 @@
 
 namespace Nooku\Library;
 
-require_once dirname(__FILE__) . '/interface.php';
-require_once dirname(__FILE__) . '/locator/interface.php';
-require_once dirname(__FILE__) . '/locator/abstract.php';
-require_once dirname(__FILE__) . '/locator/library.php';
-require_once dirname(__FILE__) . '/registry/interface.php';
-require_once dirname(__FILE__) . '/registry/registry.php';
-require_once dirname(__FILE__) . '/registry/cache.php';
+require_once dirname(__FILE__).'/interface.php';
+require_once dirname(__FILE__).'/locator/interface.php';
+require_once dirname(__FILE__).'/locator/abstract.php';
+require_once dirname(__FILE__).'/locator/library.php';
+require_once dirname(__FILE__).'/registry/interface.php';
+require_once dirname(__FILE__).'/registry/registry.php';
+require_once dirname(__FILE__).'/registry/cache.php';
 
 /**
  * Class Loader

--- a/library/class/loader.php
+++ b/library/class/loader.php
@@ -9,13 +9,13 @@
 
 namespace Nooku\Library;
 
-require_once dirname(__FILE__).'/interface.php';
-require_once dirname(__FILE__).'/locator/interface.php';
-require_once dirname(__FILE__).'/locator/abstract.php';
-require_once dirname(__FILE__).'/locator/library.php';
-require_once dirname(__FILE__).'/registry/interface.php';
-require_once dirname(__FILE__).'/registry/registry.php';
-require_once dirname(__FILE__).'/registry/cache.php';
+require_once dirname(__FILE__) . '/interface.php';
+require_once dirname(__FILE__) . '/locator/interface.php';
+require_once dirname(__FILE__) . '/locator/abstract.php';
+require_once dirname(__FILE__) . '/locator/library.php';
+require_once dirname(__FILE__) . '/registry/interface.php';
+require_once dirname(__FILE__) . '/registry/registry.php';
+require_once dirname(__FILE__) . '/registry/cache.php';
 
 /**
  * Class Loader
@@ -40,8 +40,6 @@ class ClassLoader implements ClassLoaderInterface
     protected $_locators = array();
 
     /**
-     * Class/Namespace => locator map
-     *
      * @var array
      */
     protected $_namespaces = array('*' => array());
@@ -87,7 +85,7 @@ class ClassLoader implements ClassLoaderInterface
         $this->registerLocator(new ClassLocatorLibrary($config));
 
         //Register the Nooku\Library namesoace
-        $this->getLocator('library')->registerNamespace(__NAMESPACE__, dirname(dirname(__FILE__)));
+        $this->registerLocatorNamespaces( 'library', [__NAMESPACE__ => dirname(dirname(__FILE__))]);
 
         //Register the loader with the PHP autoloader
         $this->register();
@@ -300,11 +298,17 @@ class ClassLoader implements ClassLoaderInterface
     }
 
     /**
-     * @param $namespace
-     * @param $type
+     * Registers namesapces against a locator
+     *
+     * @param $locator string|ClassLocatorInterface The locator to register namespaces against
+     * @param $namespace array An array where index is the namespace and value is the path
      */
-    public function registerLocatorNamespaces(ClassLocatorInterface $locator, array $namespaces)
+    public function registerLocatorNamespaces($locator, array $namespaces)
     {
+        if( !$locator instanceof ClassLocatorInterface ){
+            $locator = $this->getLocator($locator);
+        }
+
         $name = $locator->getName();
 
         //Ensure locator is register already
@@ -317,7 +321,7 @@ class ClassLoader implements ClassLoaderInterface
             $namespaces = array('*' => null);
         }
 
-        foreach($namespaces as $namespace => $paths) {
+        foreach($namespaces as $namespace => $path) {
 
             $namespace = trim($namespace, '\\');
 
@@ -326,7 +330,7 @@ class ClassLoader implements ClassLoaderInterface
             }
 
             if(!in_array($locator, $this->_namespaces[$namespace])) {
-                $this->_namespaces[$namespace][$name] = $paths;
+                $this->_namespaces[$namespace][$name] = $path;
             }
         }
     }

--- a/library/class/locator/abstract.php
+++ b/library/class/locator/abstract.php
@@ -48,23 +48,6 @@ abstract class ClassLocatorAbstract implements ClassLocatorInterface
     }
 
     /**
-     * Register a namespace
-     *
-     * @param  string $namespace
-     * @param  string $path The location of the namespace
-     * @return ClassLocatorInterface
-     */
-    public function registerNamespace($namespace, $path)
-    {
-        $namespace = trim($namespace, '\\');
-        $this->_namespaces[$namespace] = $path;
-
-        krsort($this->_namespaces, SORT_STRING);
-
-        return $this;
-    }
-
-    /**
      * Get a the namespace path
      *
      * @param string $namespace The namespace

--- a/library/class/locator/abstract.php
+++ b/library/class/locator/abstract.php
@@ -70,6 +70,23 @@ abstract class ClassLocatorAbstract implements ClassLocatorInterface
     }
 
     /**
+    * Register a namespace
+    *
+    * @param  string $namespace
+    * @param  string $path The location of the namespace
+    * @return ClassLocatorInterface
+    */
+    private function registerNamespace($namespace, $path)
+    {
+        $namespace = trim($namespace, '\\');
+        $this->_namespaces[$namespace] = $path;
+
+        krsort($this->_namespaces, SORT_STRING);
+
+        return $this;
+    }
+
+    /**
      * Get locator name
      *
      * @return string

--- a/library/class/locator/component.php
+++ b/library/class/locator/component.php
@@ -52,25 +52,34 @@ class ClassLocatorComponent extends ClassLocatorAbstract
      * Get a fully qualified path based on a class name
      *
      * @param  string $class    The class name
+     * @param  string $namespace The namespace/prefix the class was matched against
      * @param  string $basepath The basepath to use to find the class
      * @return string|false     Returns canonicalized absolute pathname or FALSE of the class could not be found.
      */
-    public function locate($class, $basepath)
+    public function locate($class, $namespace, $basepath)
 	{
-        $classname = str_replace(array($class, '\\'), '', '\\'.$class);
+        if(empty($namespace) && strpos($class, '\\')) {
+            return false;
+        }
+
+        if(strpos('\\'.$class, '\\'.$namespace) !== 0) {
+            return false;
+        }
+
+        $class = str_replace(array($namespace, '\\'), '', '\\'.$class);
 
         /*
          * Exception rule for Exception classes
          *
          * Transform class to lower case to always load the exception class from the /exception/ folder.
          */
-        if($pos = strpos($classname, 'Exception'))
+        if($pos = strpos($class, 'Exception'))
         {
-            $filename  = substr($classname, $pos + strlen('Exception'));
-            $classname = str_replace($filename, ucfirst(strtolower($filename)), $classname);
+            $filename  = substr($class, $pos + strlen('Exception'));
+            $class = str_replace($filename, ucfirst(strtolower($filename)), $class);
         }
 
-        $parts = explode(' ', strtolower(preg_replace('/(?<=\\w)([A-Z])/', ' \\1', $classname)));
+        $parts = explode(' ', strtolower(preg_replace('/(?<=\\w)([A-Z])/', ' \\1', $class)));
 
         $file  = array_pop($parts);
 

--- a/library/class/locator/component.php
+++ b/library/class/locator/component.php
@@ -57,49 +57,35 @@ class ClassLocatorComponent extends ClassLocatorAbstract
      */
     public function locate($class, $basepath)
 	{
-        //Find the class
-        foreach($this->getNamespaces() as $namespace => $basepath)
+        $classname = str_replace(array($class, '\\'), '', '\\'.$class);
+
+        /*
+         * Exception rule for Exception classes
+         *
+         * Transform class to lower case to always load the exception class from the /exception/ folder.
+         */
+        if($pos = strpos($classname, 'Exception'))
         {
-            if(empty($namespace) && strpos($class, '\\')) {
-                continue;
-            }
-
-            if(strpos('\\'.$class, '\\'.$namespace) !== 0) {
-                continue;
-            }
-
-            $class = str_replace(array($namespace, '\\'), '', '\\'.$class);
-
-            /*
-             * Exception rule for Exception classes
-             *
-             * Transform class to lower case to always load the exception class from the /exception/ folder.
-             */
-            if($pos = strpos($class, 'Exception'))
-            {
-                $filename  = substr($class, $pos + strlen('Exception'));
-                $class = str_replace($filename, ucfirst(strtolower($filename)), $class);
-            }
-
-            $parts = explode(' ', strtolower(preg_replace('/(?<=\\w)([A-Z])/', ' \\1', $class)));
-
-            $file  = array_pop($parts);
-
-            if(count($parts)){
-                $path = implode('/', $parts) . '/' . $file;
-            } else {
-                $path = $file . '/' . $file;
-            }
-
-            $result = $basepath . '/' . $path . '.php';
-
-            if (!is_file($result) && count($parts)) {
-                $result = $basepath . '/' . $path . '/' . $file . '.php';
-            }
-
-            return $result;
+            $filename  = substr($classname, $pos + strlen('Exception'));
+            $classname = str_replace($filename, ucfirst(strtolower($filename)), $classname);
         }
 
-		return false;
+        $parts = explode(' ', strtolower(preg_replace('/(?<=\\w)([A-Z])/', ' \\1', $classname)));
+
+        $file  = array_pop($parts);
+
+        if(count($parts)){
+            $path = implode('/', $parts) . '/' . $file;
+        } else {
+            $path = $file . '/' . $file;
+        }
+
+        $result = $basepath . '/' . $path . '.php';
+
+        if (!is_file($result) && count($parts)) {
+            $result = $basepath . '/' . $path . '/' . $file . '.php';
+        }
+
+        return $result;
 	}
 }

--- a/library/class/locator/composer.php
+++ b/library/class/locator/composer.php
@@ -40,6 +40,9 @@ class ClassLocatorComposer extends ClassLocatorAbstract
      */
     public function __construct($config = array())
     {
+        $config['namespaces'] = array('*' => null);
+        parent::__construct($config);
+
         if(isset($config['vendor_path']))
         {
             if(file_exists($config['vendor_path'].'/autoload.php'))
@@ -57,7 +60,7 @@ class ClassLocatorComposer extends ClassLocatorAbstract
      * @param  string $basepath The basepath to use to find the class
      * @return string|false     Returns canonicalized absolute pathname or FALSE of the class could not be found.
      */
-    public function locate($class, $basepath)
+    public function locate($class, $namespace, $basepath)
 	{
         $path = false;
 

--- a/library/class/locator/composer.php
+++ b/library/class/locator/composer.php
@@ -45,7 +45,7 @@ class ClassLocatorComposer extends ClassLocatorAbstract
             if(file_exists($config['vendor_path'].'/autoload.php'))
             {
                 //Let Nooku proxy class loading
-                $this->_loader = require $config['vendor_path'].'/autoload.php';
+                $this->_loader = require_once $config['vendor_path'].'/autoload.php';
             }
         }
     }

--- a/library/class/locator/interface.php
+++ b/library/class/locator/interface.php
@@ -34,15 +34,6 @@ interface ClassLocatorInterface
     public function locate($class, $basepath);
 
     /**
-     * Register a namespace
-     *
-     * @param  string $namespace
-     * @param  string $path The location of the namespace
-     * @return ClassLocatorInterface
-     */
-    public function registerNamespace($namespace, $paths);
-
-    /**
      * Get the namespace path
      *
      * @param string $namespace The namespace

--- a/library/class/locator/interface.php
+++ b/library/class/locator/interface.php
@@ -28,10 +28,11 @@ interface ClassLocatorInterface
      * Get a fully qualified path based on a class name
      *
      * @param  string $class    The class name
+     * @param  string $namespace The namespace/prefix the class was matched against
      * @param  string $basepath The basepath to use to find the class
      * @return string|false     Returns canonicalized absolute pathname or FALSE of the class could not be found.
      */
-    public function locate($class, $basepath);
+    public function locate($class, $namespace, $basepath);
 
     /**
      * Get the namespace path

--- a/library/class/locator/library.php
+++ b/library/class/locator/library.php
@@ -51,26 +51,27 @@ class ClassLocatorLibrary extends ClassLocatorAbstract
      * Get a fully qualified path based on a class name
      *
      * @param  string $class    The class name
+     * @param  string $namespace The namespace/prefix the class was matched against
      * @param  string $basepath The basepath to use to find the class
      * @return string|false     Returns canonicalized absolute pathname or FALSE of the class could not be found.
      */
-    public function locate($class, $basepath)
-    {
+    public function locate($class, $namespace, $basepath)
+	{
         //Remove the namespace from the class name
-        $classname = ltrim(substr($class, strlen($class)), '\\');
+        $class = ltrim(substr($class, strlen($namespace)), '\\');
 
         /*
          * Exception rule for Exception classes
          *
          * Transform class to lower case to always load the exception class from the /exception/ folder.
          */
-        if($pos = strpos($classname, 'Exception'))
+        if($pos = strpos($class, 'Exception'))
         {
-            $filename  = substr($classname, $pos + strlen('Exception'));
-            $classname = str_replace($filename, ucfirst(strtolower($filename)), $classname);
+            $filename  = substr($class, $pos + strlen('Exception'));
+            $class = str_replace($filename, ucfirst(strtolower($filename)), $class);
         }
 
-        $parts = explode(' ', preg_replace('/(?<=\\w)([A-Z])/', ' \\1',  $classname));
+        $parts = explode(' ', preg_replace('/(?<=\\w)([A-Z])/', ' \\1',  $class));
         $path  = strtolower(implode('/', $parts));
 
         if(count($parts) == 1) {

--- a/library/class/locator/library.php
+++ b/library/class/locator/library.php
@@ -55,46 +55,33 @@ class ClassLocatorLibrary extends ClassLocatorAbstract
      * @return string|false     Returns canonicalized absolute pathname or FALSE of the class could not be found.
      */
     public function locate($class, $basepath)
-	{
-        foreach($this->getNamespaces() as $namespace => $basepath)
+    {
+        //Remove the namespace from the class name
+        $classname = ltrim(substr($class, strlen($class)), '\\');
+
+        /*
+         * Exception rule for Exception classes
+         *
+         * Transform class to lower case to always load the exception class from the /exception/ folder.
+         */
+        if($pos = strpos($classname, 'Exception'))
         {
-            if(empty($namespace) && strpos($class, '\\')) {
-                continue;
-            }
-
-            if(strpos('\\'.$class, '\\'.$namespace) !== 0) {
-                continue;
-            }
-
-            //Remove the namespace from the class name
-            $class = ltrim(substr($class, strlen($namespace)), '\\');
-
-            /*
-             * Exception rule for Exception classes
-             *
-             * Transform class to lower case to always load the exception class from the /exception/ folder.
-             */
-            if($pos = strpos($class, 'Exception'))
-            {
-                $filename  = substr($class, $pos + strlen('Exception'));
-                $class = str_replace($filename, ucfirst(strtolower($filename)), $class);
-            }
-
-            $parts = explode(' ', preg_replace('/(?<=\\w)([A-Z])/', ' \\1',  $class));
-            $path  = strtolower(implode('/', $parts));
-
-            if(count($parts) == 1) {
-                $path = $path.'/'.$path;
-            }
-
-            $file = $basepath.'/'.$path.'.php';
-            if(!is_file($file)) {
-                $file = $basepath.'/'.$path.'/'.strtolower(array_pop($parts)).'.php';
-            }
-
-            return $file;
+            $filename  = substr($classname, $pos + strlen('Exception'));
+            $classname = str_replace($filename, ucfirst(strtolower($filename)), $classname);
         }
 
-		return false;
+        $parts = explode(' ', preg_replace('/(?<=\\w)([A-Z])/', ' \\1',  $classname));
+        $path  = strtolower(implode('/', $parts));
+
+        if(count($parts) == 1) {
+            $path = $path.'/'.$path;
+        }
+
+        $file = $basepath.'/'.$path.'.php';
+        if(!is_file($file)) {
+            $file = $basepath.'/'.$path.'/'.strtolower(array_pop($parts)).'.php';
+        }
+
+        return $file;
 	}
 }

--- a/library/object/bootstrapper/bootstrapper.php
+++ b/library/object/bootstrapper/bootstrapper.php
@@ -158,7 +158,7 @@ final class ObjectBootstrapper extends Object implements ObjectBootstrapperInter
              * Locators are always setup as the  cannot be cached in the registry objects.
              */
             foreach($this->_namespaces as $namespace => $path) {
-                $manager->getClassLoader()->getLocator('component')->registerNamespace($namespace, $path);
+                $manager->getClassLoader()->registerLocatorNamespaces('component', array($namespace => $path));
             }
 
             /*


### PR DESCRIPTION
Currently, class locators iterate over the namespace map when `locate()` is called, each locator does this for every class, regardless of if it matches the namespaces it is registered for.

This patch creates a namespace/class registry, that maps to locators & paths. This allows the loader to perform mapping and only call `locate()` on the locators that are registered for a particular namespace/prefix.