### PR TITLE
Fixed ClassRegistryCache unsetting offsets that dont exist

### DIFF
--- a/library/class/registry/cache.php
+++ b/library/class/registry/cache.php
@@ -124,7 +124,10 @@ class ClassRegistryCache extends ClassRegistry
     public function offsetUnset($offset)
     {
         apc_delete($this->getNamespace().'-class_'.$offset);
-        parent::offsetUnset($offset);
+        
+        if(parent::offsetExists($offset)){
+            parent::offsetUnset($offset);
+        }
     }
 
     /**


### PR DESCRIPTION
As the values are lazy loaded from the cache, if the class is instantiated and thus the value not set, unsetting a non-existent value causes an exception to be thrown. This patch adds a check that the value exists